### PR TITLE
Handle API failures gracefully

### DIFF
--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -17,8 +17,12 @@ def fetch_data():
         "interval": "daily",
     }
     headers = {"accept": "application/json"}
-    resp = requests.get(url, params=params, headers=headers)
-    resp.raise_for_status()
+    try:
+        resp = requests.get(url, params=params, headers=headers)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Error fetching data from CoinGecko: {exc}")
+        return pd.DataFrame()
     data = resp.json()
     # Extract timestamps and prices
     prices = data.get("prices", [])


### PR DESCRIPTION
## Summary
- improve error handling in `fetch_data()`

## Testing
- `python block_price_prediction.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a3d0d6388325b534b279c11147c9