### PR TITLE
Add timeout to CoinGecko request

### DIFF
--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -19,7 +19,7 @@ def fetch_data():
     }
     headers = {"accept": "application/json"}
     try:
-        resp = requests.get(url, params=params, headers=headers)
+        resp = requests.get(url, params=params, headers=headers, timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         print(f"Error fetching data from CoinGecko: {exc}")


### PR DESCRIPTION
## Summary
- avoid indefinite blocking on API call by adding a timeout

## Testing
- `python -m py_compile block_price_prediction.py`
- *(optional)* `python block_price_prediction.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6855ad77983c8325bbfe658519568f78