### PR TITLE
Support headless plot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Run the prediction script:
 ```
 python block_price_prediction.py
 ```
+
+The chart will be saved to `prediction.png` in the current directory. Use the
+`--show` flag if you want to display the plot as well:
+
+```
+python block_price_prediction.py --show
+```

--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -5,6 +5,7 @@ from sklearn.preprocessing import MinMaxScaler
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import LSTM, Dense
 import matplotlib.pyplot as plt
+import argparse
 
 # Fetch daily price data for Blockasset (BLOCK) from CoinGecko
 
@@ -76,6 +77,16 @@ def predict_next_day(model, last_sequence, scaler):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Predict Blockasset prices using an LSTM model"
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Display the plot after saving it to disk",
+    )
+    args = parser.parse_args()
+
     df = fetch_data()
     X, y, scaler = preprocess_data(df)
     model = build_lstm_model((X.shape[1], X.shape[2]))
@@ -95,4 +106,6 @@ if __name__ == "__main__":
     )
     plt.xlabel("Date")
     plt.ylabel("Price (USD)")
-    plt.show()
+    plt.savefig("prediction.png")
+    if args.show:
+        plt.show()


### PR DESCRIPTION
## Summary
- ensure prediction chart is written to `prediction.png`
- optionally show the plot via `--show`
- document the new behavior in the README

## Testing
- `pip install -q -r requirements.txt`
- `python block_price_prediction.py --help | head -n 5`
- `python block_price_prediction.py --show >/tmp/script_output.txt && tail -n 5 /tmp/script_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6855ad7a22348325a3dc7cf7771737d9