### PR TITLE
Add hourly Blockasset predictions

### DIFF
--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -7,16 +7,16 @@ from tensorflow.keras.layers import LSTM, Dense
 import matplotlib.pyplot as plt
 import argparse
 
-# Fetch daily price data for Blockasset (BLOCK) from CoinGecko
+# Fetch hourly price data for Blockasset (BLOCK) from CoinGecko
 
 
 def fetch_data():
     url = "https://api.coingecko.com/api/v3/coins/blockasset/market_chart"
     params = {
         "vs_currency": "usd",
-        # using a fixed window as CoinGecko may reject very large ranges
-        "days": 365,
-        "interval": "daily",
+        # fetch the entire available history at an hourly interval
+        "days": "max",
+        "interval": "hourly",
     }
     headers = {"accept": "application/json"}
     try:
@@ -34,10 +34,10 @@ def fetch_data():
     df.drop('timestamp', axis=1, inplace=True)
     return df
 
-# Preprocess data: scale prices and create sequences
+# Preprocess data: scale prices and create hourly sequences
 
 
-def preprocess_data(df, seq_len=5):
+def preprocess_data(df, seq_len=24):
     scaler = MinMaxScaler(feature_range=(0, 1))
     scaled = scaler.fit_transform(df[['price']])
     sequences = []
@@ -67,13 +67,19 @@ def train_model(model, X_train, y_train, epochs=50):
     model.fit(X_train, y_train, epochs=epochs, verbose=0)
     return model
 
-# Predict the next day price using the last sequence
+# Predict the next n hours using the last sequence
 
 
-def predict_next_day(model, last_sequence, scaler):
-    pred_scaled = model.predict(last_sequence, verbose=0)
-    pred_price = scaler.inverse_transform(pred_scaled)
-    return pred_price[0, 0]
+def predict_next_hours(model, last_sequence, scaler, n_hours=24):
+    """Iteratively predict the next `n_hours` prices."""
+    seq = last_sequence[0]
+    predictions = []
+    for _ in range(n_hours):
+        pred_scaled = model.predict(seq[np.newaxis, :, :], verbose=0)
+        predictions.append(pred_scaled[0, 0])
+        seq = np.vstack([seq[1:], pred_scaled[0]])
+    preds = scaler.inverse_transform(np.array(predictions).reshape(-1, 1))
+    return preds[:, 0]
 
 
 if __name__ == "__main__":
@@ -92,10 +98,12 @@ if __name__ == "__main__":
     model = build_lstm_model((X.shape[1], X.shape[2]))
     model = train_model(model, X, y, epochs=50)
 
-    # Use the last seq_len days to predict the next day
+    # Use the last seq_len hours to predict the next 24 hours
     last_sequence = X[-1:]
-    next_day_price = predict_next_day(model, last_sequence, scaler)
-    print(f"Predicted next day price: ${next_day_price:.4f}")
+    next_prices = predict_next_hours(model, last_sequence, scaler, n_hours=24)
+    print("Next 24 hour predictions:")
+    for i, price in enumerate(next_prices, start=1):
+        print(f"Hour +{i}: ${price:.4f}")
 
     # Plot the last 100 actual prices
     last_100 = df[-100:].copy()
@@ -104,10 +112,15 @@ if __name__ == "__main__":
         label="Actual",
     )
 
-    # Draw a line from the last actual price to the predicted next day price
-    pred_dates = [last_100.index[-1], last_100.index[-1] + pd.Timedelta(days=1)]
-    pred_values = [last_100['price'].iloc[-1], next_day_price]
-    ax.plot(pred_dates, pred_values, label="Predicted", color="orange")
+    # Plot predicted next 24 hours as a line starting from the last actual point
+    pred_dates = [last_100.index[-1] + pd.Timedelta(hours=i) for i in range(1, 25)]
+    pred_values = next_prices
+    ax.plot(
+        [last_100.index[-1]] + pred_dates,
+        [last_100['price'].iloc[-1]] + pred_values.tolist(),
+        label="Predicted",
+        color="orange",
+    )
 
     ax.set_xlabel("Date")
     ax.set_ylabel("Price (USD)")


### PR DESCRIPTION
## Summary
- fetch hourly Blockasset prices going back to the beginning
- train on hourly sequences and predict the next 24 hours
- output 24 individual hourly predictions
- update plot to draw predicted hourly prices

## Testing
- `pip install -r requirements.txt`
- `python block_price_prediction.py` *(fails: 401 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_6855c2658a58832596f6cb391a2cbb65