### PR TITLE
Fix start timestamp setup in price prediction script

### DIFF
--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -17,14 +17,12 @@ from tensorflow.keras.models import Sequential
 def fetch_data() -> pd.DataFrame:
     """Fetch hourly price data for Blockasset from the last year."""
 
-def fetch_data():
-    url = "https://api.coingecko.com/api/v3/coins/blockasset/market_chart"
-    params = {
-        "vs_currency": "usd",
-        # fetch the entire available history at an hourly interval
-        "days": "max",
-        "interval": "hourly",
-    }
+    end_ts = int(time.time())
+    start_ts = end_ts - 365 * 24 * 3600
+    step = 90 * 24 * 3600  # 90 days
+    url = "https://api.coingecko.com/api/v3/coins/blockasset/market_chart/range"
+
+    all_prices: List[List[int]] = []
     headers = {"accept": "application/json"}
 
     cur = start_ts


### PR DESCRIPTION
## Summary
- correct `fetch_data` setup to define `start_ts` relative to `end_ts`
- ensure data range uses correct market_chart API

## Testing
- `python -m py_compile block_price_prediction.py`


------
https://chatgpt.com/codex/tasks/task_e_68571b9ef168832592406861aa301a3b