### PR TITLE
Disable GPU logs in TensorFlow

### DIFF
--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -6,6 +6,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import requests
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'       # suppress INFO and WARNING logs
+os.environ['CUDA_VISIBLE_DEVICES'] = '-1'      # disable GPU detection
+import tensorflow as tf
+tf.get_logger().setLevel('ERROR')
 from sklearn.preprocessing import MinMaxScaler
 from tensorflow.keras.layers import LSTM, Dense, Input
 from tensorflow.keras.models import Sequential


### PR DESCRIPTION
## Summary
- stop TensorFlow from detecting GPUs and logging INFO/WARNING messages
- set TensorFlow logger level to `ERROR`

## Testing
- `pip install --quiet -r requirements.txt`
- `python block_price_prediction.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685733d79d00832593bffa99bd8dba96