### PR TITLE
Switch to tensorflow-cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Install the Python dependencies (it's recommended to do this inside a virtual en
 pip install -r requirements.txt
 ```
 
+Note that this project uses the CPU-only TensorFlow package (`tensorflow-cpu`). Installing the GPU variant (`tensorflow`) on a system without CUDA may produce errors.
+
 ## Usage
 
 Run the prediction script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests
 pandas
 numpy
 scikit-learn
-tensorflow
+tensorflow-cpu
 matplotlib


### PR DESCRIPTION
## Summary
- use the `tensorflow-cpu` package
- document that the project requires the CPU-only TensorFlow package and GPU installs without CUDA may fail

## Testing
- `python -m py_compile block_price_prediction.py`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6857ac8f6634832584cadeeab0d51b4c