### PR TITLE
Use CPU-only TensorFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Block2025
 
-This repository contains a simple script to predict the Blockasset (BLOCK) price using an LSTM neural network. The script fetches historical price data from CoinGecko and trains a model using TensorFlow and scikit-learn.
+This repository contains a simple script to predict the Blockasset (BLOCK) price using an LSTM neural network. The script fetches historical price data from CoinGecko and trains a model using the CPU-only TensorFlow package and scikit-learn.
 
 ## Installation
 
@@ -9,6 +9,7 @@ Install the Python dependencies (it's recommended to do this inside a virtual en
 ```
 pip install -r requirements.txt
 ```
+The requirements file uses `tensorflow-cpu`, which installs TensorFlow without any GPU libraries.
 
 ## Usage
 

--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -7,9 +7,10 @@ import numpy as np
 import pandas as pd
 import requests
 import os
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'       # suppress INFO and WARNING logs
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'       # suppress non-critical TensorFlow warnings
 os.environ['CUDA_VISIBLE_DEVICES'] = '-1'      # disable GPU detection
 import tensorflow as tf
+tf.config.set_visible_devices([], 'GPU')       # explicitly disable GPU detection
 tf.get_logger().setLevel('ERROR')
 from sklearn.preprocessing import MinMaxScaler
 from tensorflow.keras.layers import LSTM, Dense, Input

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests
 pandas
 numpy
 scikit-learn
-tensorflow
+tensorflow-cpu
 matplotlib


### PR DESCRIPTION
## Summary
- depend on `tensorflow-cpu` instead of the full GPU build
- document that the requirements use the CPU-only TensorFlow package
- silence more TensorFlow logs and disable GPU detection in the script

## Testing
- `python -m py_compile block_price_prediction.py`
- `python block_price_prediction.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6857ac7a1de08325947e69d481a0db80