### PR TITLE
Add CPU usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install the Python dependencies (it's recommended to do this inside a virtual en
 pip install -r requirements.txt
 ```
 
+**Note:** The script is designed to run on the CPU. If your environment
+lacks GPU support, install the `tensorflow-cpu` package to avoid any
+CUDA-related errors.
+
 ## Usage
 
 Run the prediction script:


### PR DESCRIPTION
## Summary
- clarify that the script is meant for CPU usage in README
- mention installing `tensorflow-cpu` for environments without GPUs

## Testing
- `python -m py_compile block_price_prediction.py`
- `python block_price_prediction.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6857ac7cee848325a096f0b066c3ba8e