### PR TITLE
Switch to tensorflow-cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple script to predict the Blockasset (BLOCK) price
 
 ## Installation
 
-Install the Python dependencies (it's recommended to do this inside a virtual environment):
+Install the Python dependencies (it's recommended to do this inside a virtual environment). The requirements use the CPU-only TensorFlow build, which avoids CUDA-related errors:
 
 ```
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests
 pandas
 numpy
 scikit-learn
-tensorflow
+tensorflow-cpu
 matplotlib


### PR DESCRIPTION
## Summary
- use `tensorflow-cpu` instead of GPU build
- mention that the requirements avoid CUDA errors when installing

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
import tensorflow as tf
print('imported tensorflow version', tf.__version__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6857ac82a00c8325b23b92c0503ba133