### PR TITLE
Add trade simulation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ python block_price_prediction.py --show
 
 ```
 
+## Trade Simulation
 
+A simple script `trade_simulation.py` shows a hypothetical trading example. It starts with $100 on 2025-03-01 and applies a 0.2% commission to each buy and sell. Run it with:
 
-.venv/bin/pip install -r requirements.txt 
-.venv/bin/python block_price_prediction.py 
+```bash
+python trade_simulation.py
+```

--- a/trade_simulation.py
+++ b/trade_simulation.py
@@ -1,0 +1,47 @@
+import datetime
+
+
+def simulate_trades(
+    initial_balance: float = 100.0,
+    start_date: datetime.date = datetime.date(2025, 3, 1),
+    commission: float = 0.002,
+):
+    """Simulate monthly trades with a commission on each buy and sell."""
+
+    # Hypothetical monthly returns from March to October 2025
+    months = [
+        ("March", 0.05),
+        ("April", -0.03),
+        ("May", 0.04),
+        ("June", 0.02),
+        ("July", -0.01),
+        ("August", 0.03),
+        ("September", -0.02),
+        ("October", 0.04),
+    ]
+
+    balance = initial_balance
+    history = []
+
+    for month, change in months:
+        # Deduct buy commission
+        balance -= balance * commission
+        # Apply monthly return
+        balance *= (1 + change)
+        # Deduct sell commission
+        balance -= balance * commission
+        history.append((month, balance))
+
+    end_date = datetime.date(2025, 10, 31)
+    return history, end_date, balance
+
+
+def main():
+    history, end_date, final_balance = simulate_trades()
+    for month, bal in history:
+        print(f"End of {month}: ${bal:.2f}")
+    print(f"\nFinal balance on {end_date:%Y-%m-%d}: ${final_balance:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `trade_simulation.py` for a simple trading scenario with 0.2% commission
- clean up `README.md` and document how to run the simulation

## Testing
- `python -m py_compile trade_simulation.py block_price_prediction.py`
- `python trade_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_6857b3160a1c8325922d23385ab41afe