### PR TITLE
Add epochs flag for quicker training

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ python block_price_prediction.py
 ```
 
 The chart will be saved to `prediction.png` in the current directory. Use the
-`--show` flag if you want to display the plot as well:
+`--show` flag if you want to display the plot as well. You can also control the
+number of training epochs with the `--epochs` option:
 
 ```
-python block_price_prediction.py --show
+python block_price_prediction.py --show --epochs 5
 
 ```
 

--- a/block_price_prediction.py
+++ b/block_price_prediction.py
@@ -114,6 +114,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Display the plot after saving it to disk",
     )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=50,
+        help="Number of training epochs (default: 50)",
+    )
     args = parser.parse_args()
 
     df = fetch_data()
@@ -124,7 +130,7 @@ if __name__ == "__main__":
         print(f"Data start: {df.index[0]}  Data end: {df.index[-1]}")
     X, y, scaler = preprocess_data(df)
     model = build_lstm_model((X.shape[1], X.shape[2]))
-    model = train_model(model, X, y, epochs=50)
+    model = train_model(model, X, y, epochs=args.epochs)
 
     # Use the last seq_len hours to predict the next 24 hours
     last_sequence = X[-1:]


### PR DESCRIPTION
## Summary
- add `--epochs` parameter to `block_price_prediction.py`
- train the model with the requested number of epochs
- document the new option in README

## Testing
- `python block_price_prediction.py --epochs 1 > price_output.txt && tail -n 20 price_output.txt`
- `python trade_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_6857bb43db048325bc3cefc0c35bea2c