### PR TITLE
Improve data caching for Block price script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+# Generated files
+block_prices.csv
+prediction.png

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ CUDA-related errors.
 
 Run the prediction script:
 
-The script downloads the latest price data from CoinGecko, trains an LSTM model and prints the predicted prices for the next 24 hours by default. After training a chart window will open showing recent prices along with the prediction.
+The script downloads the latest price data from CoinGecko, trains an LSTM model
+and prints the predicted prices for the next 24 hours by default. The fetched
+prices are cached in `block_prices.csv`; if this file is newer than 24 hours the
+data is loaded from disk instead of downloading again. After training a chart
+window will open showing recent prices along with the prediction.
 
 ```
 python block_price_prediction.py


### PR DESCRIPTION
## Summary
- cache `block_price_prediction.py` price data to `block_prices.csv`
- ignore generated files
- document cache behavior in README

## Testing
- `python -m pip install -r requirements.txt`
- `python block_price_prediction.py --epochs 1 --hours 1`
- `python trade_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_6857e22f9db88325bd01568c30f6486e