### PR TITLE
Add OHLC fetching utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ The previous standalone `trade_simulation.py` has been incorporated into
 `block_analysis.py`. When you run the analysis script a short example simulation
 is executed automatically and the monthly balances are printed.
 
+
+## Fetching OHLC Data
+
+Use `fetch_ohlc.py` to download open, high, low and close prices from CoinGecko. The script prints the first few rows or saves them to CSV.
+
+```bash
+python fetch_ohlc.py bitcoin --days 30 --outfile btc_ohlc.csv
+```
+
+The `days` option accepts `1, 7, 14, 30, 90, 180, 365` or `max`.

--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,0 +1,48 @@
+import argparse
+import requests
+import pandas as pd
+
+
+ALLOWED_DAYS = {1, 7, 14, 30, 90, 180, 365, "max"}
+
+
+def fetch_ohlc(coin_id: str, vs_currency: str = "usd", days: str | int = 30) -> pd.DataFrame:
+    if isinstance(days, str) and days.isdigit():
+        days = int(days)
+    if days not in ALLOWED_DAYS:
+        allowed = ", ".join(str(d) for d in ALLOWED_DAYS)
+        raise ValueError(f"days must be one of {allowed}")
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/ohlc"
+    params = {"vs_currency": vs_currency, "days": days}
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close"])
+    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+    df.set_index("date", inplace=True)
+    df.drop("timestamp", axis=1, inplace=True)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch OHLC data from CoinGecko")
+    parser.add_argument("coin_id", help="Coin id on CoinGecko, e.g. bitcoin")
+    parser.add_argument(
+        "--days",
+        default=30,
+        help="Number of days (1/7/14/30/90/180/365/max)",
+    )
+    parser.add_argument("--vs", default="usd", help="Quote currency (default: usd)")
+    parser.add_argument("--outfile", help="Optional CSV file to save results")
+    args = parser.parse_args()
+
+    df = fetch_ohlc(args.coin_id, vs_currency=args.vs, days=args.days)
+    if args.outfile:
+        df.to_csv(args.outfile)
+        print(f"Saved {len(df)} rows to {args.outfile}")
+    else:
+        print(df.head())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fetch_ohlc.py` script for downloading OHLC data from CoinGecko
- document new script usage in README

## Testing
- `python -m py_compile fetch_ohlc.py`
- `python fetch_ohlc.py bitcoin --days 1 | head -n 5`
- `python fetch_ohlc.py bitcoin --days 1 --outfile test.csv`

------
https://chatgpt.com/codex/tasks/task_e_6858172284f88325956cd843fef07e41