### PR TITLE
Add simple OHLC downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ The previous standalone `trade_simulation.py` has been incorporated into
 `block_analysis.py`. When you run the analysis script a short example simulation
 is executed automatically and the monthly balances are printed.
 
+
+## Fetching OHLC Data
+
+Use `fetch_ohlc.py` to download open, high, low and close prices for the
+Blockasset token from CoinGecko.
+
+```bash
+python fetch_ohlc.py
+```
+
+The script fetches the last 30 days of hourly data and prints the first few
+rows to the console.

--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,0 +1,30 @@
+import requests
+import pandas as pd
+
+
+COIN_ID = "blockasset"
+VS_CURRENCY = "usd"
+DAYS = 30  # returns 1 hour intervals for up to 90 days
+
+
+def fetch_ohlc() -> pd.DataFrame:
+    """Download OHLC values for the configured coin."""
+    url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}/ohlc"
+    params = {"vs_currency": VS_CURRENCY, "days": DAYS}
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close"])
+    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+    df.set_index("date", inplace=True)
+    df.drop("timestamp", axis=1, inplace=True)
+    return df
+
+
+def main() -> None:
+    df = fetch_ohlc()
+    print(df.head())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- simplify `fetch_ohlc.py` so it uses predefined settings
- update docs for the script

## Testing
- `python -m py_compile fetch_ohlc.py`
- `python fetch_ohlc.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6858172284f88325956cd843fef07e41