### PR TITLE
Enable saving OHLC data to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ is executed automatically and the monthly balances are printed.
 ## Fetching OHLC Data
 
 Use `fetch_ohlc.py` to download open, high, low and close prices for the
-Blockasset token from CoinGecko.
+Blockasset token from CoinGecko. The values are saved to a CSV file for
+later inspection. You can specify the output file with `--outfile`; it
+defaults to `ohlc.csv`.
 
 ```bash
-python fetch_ohlc.py
+python fetch_ohlc.py --outfile my_data.csv
 ```
 
-The script fetches the last 30 days of hourly data and prints the first few
-rows to the console.
+The script prints the first few rows of data and reports how many entries
+were written to the file.

--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,4 +1,5 @@
 
+import argparse
 import requests
 import pandas as pd
 
@@ -23,8 +24,21 @@ def fetch_ohlc() -> pd.DataFrame:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch OHLC data for Blockasset and save to CSV"
+    )
+    parser.add_argument(
+        "--outfile",
+        "-o",
+        default="ohlc.csv",
+        help="Output CSV file (default: ohlc.csv)",
+    )
+    args = parser.parse_args()
+
     df = fetch_ohlc()
+    df.to_csv(args.outfile)
     print(df.head())
+    print(f"Saved {len(df)} rows to {args.outfile}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `fetch_ohlc.py` to write data to a CSV file via `--outfile`
- document the new behaviour in the README

## Testing
- `python -m py_compile fetch_ohlc.py block_analysis.py block_price_prediction.py trade_simulation.py`
- `python fetch_ohlc.py --outfile test_ohlc.csv | head`

------
https://chatgpt.com/codex/tasks/task_e_68581e36e1108325b914715d5d236b07