### PR TITLE
Enable fetching up to a year of hourly OHLC data

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ is executed automatically and the monthly balances are printed.
 ## Fetching OHLC Data
 
 Use `fetch_ohlc.py` to download open, high, low and close prices for the
-Blockasset token from CoinGecko.
+Blockasset token from CoinGecko. By default the script retrieves the last
+365 days of hourly data. The values are saved to a CSV file for later
+inspection. You can specify the output file with `--outfile` and adjust the
+history length with `--days` (maximum 365).
 
 ```bash
-python fetch_ohlc.py
+python fetch_ohlc.py --outfile my_data.csv --days 120
 ```
 
-The script fetches the last 30 days of hourly data and prints the first few
-rows to the console.
+The script prints the first few rows of data and reports how many entries
+were written to the file.

--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,30 +1,64 @@
 
+import argparse
 import requests
 import pandas as pd
+import time
 
 
 COIN_ID = "blockasset"
 VS_CURRENCY = "usd"
-DAYS = 30  # returns 1 hour intervals for up to 90 days
+DEFAULT_DAYS = 365  # max history allowed by public API
 
 
-def fetch_ohlc() -> pd.DataFrame:
-    """Download OHLC values for the configured coin."""
-    url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}/ohlc"
-    params = {"vs_currency": VS_CURRENCY, "days": DAYS}
-    resp = requests.get(url, params=params, timeout=10)
-    resp.raise_for_status()
-    data = resp.json()
-    df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close"])
-    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+def fetch_ohlc(days: int = DEFAULT_DAYS) -> pd.DataFrame:
+    """Download hourly OHLC data for the configured coin."""
+
+    def fetch_prices(start: int, end: int) -> list:
+        url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}/market_chart/range"
+        params = {"vs_currency": VS_CURRENCY, "from": start, "to": end}
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()["prices"]
+
+    now = int(time.time())
+    start = now - days * 86400
+    all_prices = []
+    while start < now:
+        end = min(start + 90 * 86400, now)
+        all_prices.extend(fetch_prices(start, end))
+        start = end
+
+    df = pd.DataFrame(all_prices, columns=["timestamp", "price"])
+    df["date"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
     df.set_index("date", inplace=True)
-    df.drop("timestamp", axis=1, inplace=True)
-    return df
+    df = df[~df.index.duplicated(keep="first")]
+    ohlc = df["price"].resample("1H").ohlc()
+    return ohlc
 
 
 def main() -> None:
-    df = fetch_ohlc()
+    parser = argparse.ArgumentParser(
+        description="Fetch OHLC data for Blockasset and save to CSV"
+    )
+    parser.add_argument(
+        "--outfile",
+        "-o",
+        default="ohlc.csv",
+        help="Output CSV file (default: ohlc.csv)",
+    )
+    parser.add_argument(
+        "--days",
+        "-d",
+        type=int,
+        default=DEFAULT_DAYS,
+        help="Number of days of history to fetch (max 365)",
+    )
+    args = parser.parse_args()
+
+    df = fetch_ohlc(days=min(args.days, DEFAULT_DAYS))
+    df.to_csv(args.outfile)
     print(df.head())
+    print(f"Saved {len(df)} rows to {args.outfile}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand `fetch_ohlc.py` to pull up to 365 days of hourly prices using the `market_chart/range` endpoint
- allow users to specify how many days of history to retrieve via `--days`
- document the new functionality in the README

## Testing
- `python -m py_compile fetch_ohlc.py block_analysis.py block_price_prediction.py trade_simulation.py`
- `python fetch_ohlc.py --days 1 --outfile test_ohlc.csv | head`


------
https://chatgpt.com/codex/tasks/task_e_68581e36e1108325b914715d5d236b07