### PR TITLE
Enable gate.io OHLCV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,16 @@ is executed automatically and the monthly balances are printed.
 
 ## Fetching OHLC Data
 
-Use `fetch_ohlc.py` to download open, high, low and close prices for the
-Blockasset token from CoinGecko.
+Use `fetch_ohlc.py` to download hourly candlestick data for the Blockasset
+token from gate.io. All values returned by the API—timestamp, open, high, low,
+close, volume, quote volume and the completion flag—are written to a CSV file.
+By default the script retrieves the last 365 days of history. You can specify
+the output file with `--outfile` and adjust the history length with `--days`
+(maximum 365).
 
 ```bash
-python fetch_ohlc.py
+python fetch_ohlc.py --outfile my_data.csv --days 120
 ```
 
-The script fetches the last 30 days of hourly data and prints the first few
-rows to the console.
+The script prints the first few rows of data and reports how many entries
+were written to the file.

--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,30 +1,97 @@
-
+import argparse
 import requests
 import pandas as pd
+import time
 
 
-COIN_ID = "blockasset"
-VS_CURRENCY = "usd"
-DAYS = 30  # returns 1 hour intervals for up to 90 days
+PAIR = "BLOCK_USDT"
+INTERVAL = "1h"
+DEFAULT_DAYS = 365  # gate.io allows up to 10000 candles (~416 days)
 
 
-def fetch_ohlc() -> pd.DataFrame:
-    """Download OHLC values for the configured coin."""
-    url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}/ohlc"
-    params = {"vs_currency": VS_CURRENCY, "days": DAYS}
-    resp = requests.get(url, params=params, timeout=10)
-    resp.raise_for_status()
-    data = resp.json()
-    df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close"])
-    df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
+def fetch_ohlc(days: int = DEFAULT_DAYS) -> pd.DataFrame:
+    """Download hourly OHLCV data for the configured pair from gate.io."""
+
+    def fetch_chunk(start: int) -> list:
+        url = "https://api.gateio.ws/api/v4/spot/candlesticks"
+        params = {
+            "currency_pair": PAIR,
+            "interval": INTERVAL,
+            "limit": 1000,
+            "from": start,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    now = int(time.time())
+    start = now - days * 86400
+    all_rows: list[list[str]] = []
+    while start < now:
+        chunk = fetch_chunk(start)
+        if not chunk:
+            break
+        all_rows.extend(chunk)
+        last_ts = int(chunk[-1][0])
+        start = last_ts + 3600
+        time.sleep(0.2)
+
+    columns = [
+        "timestamp",
+        "quote_volume",
+        "close",
+        "high",
+        "low",
+        "open",
+        "volume",
+        "complete",
+    ]
+    df = pd.DataFrame(all_rows, columns=columns)
+    df["timestamp"] = pd.to_numeric(df["timestamp"])
+    df[["open", "high", "low", "close", "volume", "quote_volume"]] = df[
+        ["open", "high", "low", "close", "volume", "quote_volume"]
+    ].astype(float)
+    df["date"] = pd.to_datetime(df["timestamp"], unit="s", utc=True)
     df.set_index("date", inplace=True)
-    df.drop("timestamp", axis=1, inplace=True)
-    return df
+    df.sort_index(inplace=True)
+    df = df[~df.index.duplicated(keep="first")]
+    return df[
+        [
+            "timestamp",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "quote_volume",
+            "complete",
+        ]
+    ]
 
 
 def main() -> None:
-    df = fetch_ohlc()
+    parser = argparse.ArgumentParser(
+        description="Fetch hourly OHLCV data from gate.io and save to CSV"
+    )
+    parser.add_argument(
+        "--outfile",
+        "-o",
+        default="ohlc.csv",
+        help="Output CSV file (default: ohlc.csv)",
+    )
+    parser.add_argument(
+        "--days",
+        "-d",
+        type=int,
+        default=DEFAULT_DAYS,
+        help="Number of days of history to fetch (max 365)",
+    )
+    args = parser.parse_args()
+
+    df = fetch_ohlc(days=min(args.days, DEFAULT_DAYS))
+    df.to_csv(args.outfile)
     print(df.head())
+    print(f"Saved {len(df)} rows to {args.outfile}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch `fetch_ohlc.py` to gate.io for OHLC data
- include volume column and hourly candles
- update README instructions about gate.io source
- add option to save OHLC data
- now store every gate.io field in the CSV

## Testing
- `python -m py_compile fetch_ohlc.py block_analysis.py block_price_prediction.py trade_simulation.py`
- `python fetch_ohlc.py --days 1 --outfile test_ohlc.csv | head`


------
https://chatgpt.com/codex/tasks/task_e_68581e36e1108325b914715d5d236b07