### PR TITLE
Add LSTM trading backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ The previous standalone `trade_simulation.py` has been incorporated into
 `block_analysis.py`. When you run the analysis script a short example simulation
 is executed automatically and the monthly balances are printed.
 
+The `TradeSimulator` also provides a `run_daily()` method that spreads the
+monthly returns over each day and returns a list of daily balances. In the
+example script the first few daily results are printed after the monthly
+summary.
+
+## LSTM Trading Example
+
+`block_analysis.py` also demonstrates an experimental `LSTMTrader` that trains
+on historical prices and performs a very naive backtest. After the monthly
+simulation finishes, the script runs the trader and prints the final balance and
+some sample trades.
+
+## Disclaimer
+
+The trading examples in this repository are for informational and educational
+purposes only. They do not constitute financial advice. Use any strategy at your
+own risk.
+
 
 ## Fetching OHLC Data
 

--- a/block_analysis.py
+++ b/block_analysis.py
@@ -205,6 +205,100 @@ class TradeSimulator:
             history.append(SimulationResult(month, balance))
         return history
 
+    def run_daily(self) -> List[SimulationResult]:
+        """Return daily balances by spreading monthly changes evenly."""
+        months = [
+            ("March", 31, 0.05),
+            ("April", 30, -0.03),
+            ("May", 31, 0.04),
+            ("June", 30, 0.02),
+            ("July", 31, -0.01),
+            ("August", 31, 0.03),
+            ("September", 30, -0.02),
+            ("October", 31, 0.04),
+        ]
+        balance = self.initial_balance
+        history: List[SimulationResult] = []
+        for month, days, change in months:
+            daily_rate = (1 + change) ** (1 / days) - 1
+            for day in range(1, days + 1):
+                balance -= balance * self.commission
+                balance *= 1 + daily_rate
+                balance -= balance * self.commission
+                label = f"{month} {day}"
+                history.append(SimulationResult(label, balance))
+        return history
+
+
+class LSTMTrader:
+    """Backtest a naive strategy using LSTM price predictions.
+
+    This example is provided for informational and educational purposes only and
+    does not constitute financial advice.
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        seq_len: int = SEQ_LEN,
+        train_size: int = 300,
+        epochs: int = EPOCHS,
+        initial_balance: float = 1000.0,
+        commission: float = 0.002,
+    ) -> None:
+        self.df = df
+        self.seq_len = seq_len
+        self.train_size = train_size
+        self.epochs = epochs
+        self.initial_balance = initial_balance
+        self.commission = commission
+        self.scaler = MinMaxScaler(feature_range=(0, 1))
+        self.model = self._build_model((seq_len, 1))
+        self.trades: List[dict] = []
+
+    def _build_model(self, input_shape) -> Sequential:
+        model = Sequential(
+            [Input(shape=input_shape), LSTM(50, activation="relu"), Dense(1)]
+        )
+        model.compile(optimizer="adam", loss="mse")
+        return model
+
+    def _prepare_data(self) -> np.ndarray:
+        return self.scaler.fit_transform(self.df[["price"]])
+
+    def backtest(self) -> float:
+        scaled = self._prepare_data()
+
+        X_train, y_train = [], []
+        for i in range(self.train_size - self.seq_len):
+            X_train.append(scaled[i : i + self.seq_len])
+            y_train.append(scaled[i + self.seq_len])
+        self.model.fit(np.array(X_train), np.array(y_train), epochs=self.epochs, verbose=0)
+
+        balance = self.initial_balance
+        holdings = 0.0
+        for i in range(self.train_size, len(self.df) - 1):
+            seq = scaled[i - self.seq_len : i]
+            pred_scaled = self.model.predict(seq[np.newaxis, :, :], verbose=0)[0, 0]
+            pred = self.scaler.inverse_transform([[pred_scaled]])[0, 0]
+            price = self.df["price"].iloc[i]
+
+            if pred > price and balance > 0:
+                qty = balance / price
+                balance -= qty * price * (1 + self.commission)
+                holdings += qty
+                self.trades.append({"time": self.df.index[i], "type": "BUY", "price": price, "qty": qty})
+            elif pred < price and holdings > 0:
+                balance += holdings * price * (1 - self.commission)
+                self.trades.append({"time": self.df.index[i], "type": "SELL", "price": price, "qty": holdings})
+                holdings = 0.0
+
+        if holdings > 0:
+            final_price = self.df["price"].iloc[-1]
+            balance += holdings * final_price * (1 - self.commission)
+            self.trades.append({"time": self.df.index[-1], "type": "SELL", "price": final_price, "qty": holdings})
+        return balance
+
 
 def plot_predictions(df: pd.DataFrame, predictions: pd.Series, outfile: str = "prediction.png") -> None:
     """Plot actual prices and predicted future prices."""
@@ -242,6 +336,21 @@ def main() -> None:
     for res in results:
         print(f"End of {res.month}: ${res.balance:.2f}")
     print(f"\nFinal balance on 2025-10-31: ${results[-1].balance:.2f}")
+
+    # Show an example of daily balances
+    daily_results = simulator.run_daily()
+    print("\nFirst 7 daily balances:")
+    for res in daily_results[:7]:
+        print(f"{res.month}: ${res.balance:.2f}")
+
+    # Demonstrate LSTM-based trading
+    trader = LSTMTrader(raw_df)
+    final_balance = trader.backtest()
+    print(f"\nLSTM trading simulation final balance: ${final_balance:.2f}")
+    if trader.trades:
+        print("First 3 trades:")
+        for t in trader.trades[:3]:
+            print(f"{t['time']:%Y-%m-%d %H:%M} {t['type']} at ${t['price']:.4f} qty {t['qty']:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `LSTMTrader` class for a simple backtest using price predictions
- run the trader at the end of `block_analysis.py`
- document the new feature and add a disclaimer in the README

## Testing
- `python block_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_685c941513fc8325b4e2a325598d397c