### PR TITLE
Clarify README plot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Run the prediction script:
 The script downloads the latest price data from CoinGecko, trains an LSTM model
 and prints the predicted prices for the next 24 hours by default. The fetched
 prices are cached in `block_prices.csv`; if this file is newer than 24 hours the
-data is loaded from disk instead of downloading again. After training a chart
-window will open showing recent prices along with the prediction.
+data is loaded from disk instead of downloading again. After training, the plot
+is saved to `prediction.png` instead of opening a chart window.
 
 ```bash
 python block_analysis.py


### PR DESCRIPTION
## Summary
- update usage section to reflect that the plot is saved to `prediction.png`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cfcddd4348325b9a6000f08c9808a