### PR TITLE
Add retry logic for network requests

### DIFF
--- a/fetch_ohlc.py
+++ b/fetch_ohlc.py
@@ -1,5 +1,7 @@
 import argparse
 import requests
+
+from request_utils import get_with_retry
 import pandas as pd
 import time
 
@@ -20,8 +22,11 @@ def fetch_ohlc(days: int = DEFAULT_DAYS) -> pd.DataFrame:
             "limit": 1000,
             "from": start,
         }
-        resp = requests.get(url, params=params, timeout=10)
-        resp.raise_for_status()
+        try:
+            resp = get_with_retry(url, params=params, timeout=10)
+        except requests.RequestException as exc:
+            print(f"Error fetching OHLC data: {exc}")
+            return []
         return resp.json()
 
     now = int(time.time())

--- a/request_utils.py
+++ b/request_utils.py
@@ -1,0 +1,28 @@
+import time
+from typing import Optional, Dict, Any
+
+import requests
+
+
+def get_with_retry(
+    url: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 10,
+    max_retries: int = 5,
+) -> requests.Response:
+    """Perform GET request with retries on network errors."""
+    for attempt in range(max_retries):
+        try:
+            response = requests.get(
+                url, params=params, headers=headers, timeout=timeout
+            )
+            response.raise_for_status()
+            return response
+        except requests.RequestException:
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(2**attempt)
+    # Should never reach here
+    raise RuntimeError("Unreachable")


### PR DESCRIPTION
## Summary
- add helper `get_with_retry` for repeated GET requests with exponential backoff
- use `get_with_retry` in data fetching utilities
- handle request failures gracefully

## Testing
- `python -m compileall -q .`
- `pip install -q -r requirements.txt`
- `python fetch_ohlc.py --days 0 --outfile /tmp/test.csv`


------
https://chatgpt.com/codex/tasks/task_e_685cfce130d48325839c9ad6b59dd78e