### PR TITLE
Handle API rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,21 @@ Run the prediction script:
 The script downloads the latest price data from CoinGecko, trains an LSTM model
 and prints the predicted prices for the next 24 hours by default. The fetched
 prices are cached in `block_prices.csv`; if this file is newer than 24 hours the
-data is loaded from disk instead of downloading again. After training a chart
-window will open showing recent prices along with the prediction.
+data is loaded from disk instead of downloading again. Should the API respond
+with "Too Many Requests" errors, the fetcher now retries automatically using a
+simple exponential backoff. After training a chart window will open showing
+recent prices along with the prediction.
 
 ```bash
 python block_analysis.py
+```
+
+You can also run the analysis on your own Gate.io CSV export using the
+`--csv` option. The loader expects a column named `close`, which will be
+treated as the price.
+
+```bash
+python block_analysis.py --csv my_data.csv
 ```
 
 The script computes several technical indicators, trains an LSTM model and
@@ -41,6 +51,24 @@ printed to the console.
 The previous standalone `trade_simulation.py` has been incorporated into
 `block_analysis.py`. When you run the analysis script a short example simulation
 is executed automatically and the monthly balances are printed.
+
+The `TradeSimulator` also provides a `run_daily()` method that spreads the
+monthly returns over each day and returns a list of daily balances. In the
+example script the first few daily results are printed after the monthly
+summary.
+
+## LSTM Trading Example
+
+`block_analysis.py` also demonstrates an experimental `LSTMTrader` that trains
+on historical prices and performs a very naive backtest. After the monthly
+simulation finishes, the script runs the trader and prints the final balance and
+some sample trades.
+
+## Disclaimer
+
+The trading examples in this repository are for informational and educational
+purposes only. They do not constitute financial advice. Use any strategy at your
+own risk.
 
 
 ## Fetching OHLC Data
@@ -58,3 +86,9 @@ python fetch_ohlc.py --outfile my_data.csv --days 120
 
 The script prints the first few rows of data and reports how many entries
 were written to the file.
+
+Once you have a CSV file you can run the main analysis script with:
+
+```bash
+python block_analysis.py --csv my_data.csv
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ summary.
 `block_analysis.py` also demonstrates an experimental `LSTMTrader` that trains
 on historical prices and performs a very naive backtest. After the monthly
 simulation finishes, the script runs the trader and prints the final balance and
-some sample trades.
+some sample trades. A chart of these buy and sell points is saved to
+`trades.png` for quick inspection.
 
 ## Disclaimer
 

--- a/block_analysis.py
+++ b/block_analysis.py
@@ -12,6 +12,7 @@ import os
 import time
 from dataclasses import dataclass
 from typing import List
+import argparse
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,13 +40,21 @@ SEQ_LEN = 24
 
 
 class DataFetcher:
-    """Fetches historical price data for Blockasset from CoinGecko."""
+    """Fetches historical price data for Blockasset from CoinGecko or a local file."""
 
-    def __init__(self, cache_file: str = CACHE_FILE) -> None:
+    def __init__(self, cache_file: str = CACHE_FILE, local_csv: str | None = None) -> None:
         self.cache_file = cache_file
+        self.local_csv = local_csv
 
     def fetch(self) -> pd.DataFrame:
         """Return a DataFrame with hourly prices."""
+        if self.local_csv:
+            df = pd.read_csv(self.local_csv, parse_dates=["date"])
+            if "close" in df.columns and "price" not in df.columns:
+                df.rename(columns={"close": "price"}, inplace=True)
+            df.set_index("date", inplace=True)
+            return df.sort_index()
+
         if os.path.exists(self.cache_file):
             file_age = time.time() - os.path.getmtime(self.cache_file)
             if file_age < 24 * 3600:
@@ -60,19 +69,37 @@ class DataFetcher:
         cur = start_ts
         headers = {"accept": "application/json"}
 
+        max_retries = 5
+
         while cur < end_ts:
             params = {
                 "vs_currency": "usd",
                 "from": cur,
                 "to": min(cur + step, end_ts),
             }
-            resp = requests.get(url, params=params, headers=headers, timeout=10)
-            resp.raise_for_status()
+            retries = 0
+            while True:
+                resp = requests.get(url, params=params, headers=headers, timeout=10)
+                if resp.status_code == 429 and retries < max_retries:
+                    wait = int(resp.headers.get("Retry-After", 2)) * (retries + 1)
+                    time.sleep(wait)
+                    retries += 1
+                    continue
+                try:
+                    resp.raise_for_status()
+                except requests.HTTPError:
+                    if retries < max_retries:
+                        time.sleep(2 ** retries)
+                        retries += 1
+                        continue
+                    raise
+                break
+
             data = resp.json()
             prices = data.get("prices", [])
             all_prices.extend(prices)
             cur += step
-            time.sleep(1)
+            time.sleep(2)
 
         df = pd.DataFrame(all_prices, columns=["timestamp", "price"])
         df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
@@ -205,6 +232,100 @@ class TradeSimulator:
             history.append(SimulationResult(month, balance))
         return history
 
+    def run_daily(self) -> List[SimulationResult]:
+        """Return daily balances by spreading monthly changes evenly."""
+        months = [
+            ("March", 31, 0.05),
+            ("April", 30, -0.03),
+            ("May", 31, 0.04),
+            ("June", 30, 0.02),
+            ("July", 31, -0.01),
+            ("August", 31, 0.03),
+            ("September", 30, -0.02),
+            ("October", 31, 0.04),
+        ]
+        balance = self.initial_balance
+        history: List[SimulationResult] = []
+        for month, days, change in months:
+            daily_rate = (1 + change) ** (1 / days) - 1
+            for day in range(1, days + 1):
+                balance -= balance * self.commission
+                balance *= 1 + daily_rate
+                balance -= balance * self.commission
+                label = f"{month} {day}"
+                history.append(SimulationResult(label, balance))
+        return history
+
+
+class LSTMTrader:
+    """Backtest a naive strategy using LSTM price predictions.
+
+    This example is provided for informational and educational purposes only and
+    does not constitute financial advice.
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        seq_len: int = SEQ_LEN,
+        train_size: int = 300,
+        epochs: int = EPOCHS,
+        initial_balance: float = 1000.0,
+        commission: float = 0.002,
+    ) -> None:
+        self.df = df
+        self.seq_len = seq_len
+        self.train_size = train_size
+        self.epochs = epochs
+        self.initial_balance = initial_balance
+        self.commission = commission
+        self.scaler = MinMaxScaler(feature_range=(0, 1))
+        self.model = self._build_model((seq_len, 1))
+        self.trades: List[dict] = []
+
+    def _build_model(self, input_shape) -> Sequential:
+        model = Sequential(
+            [Input(shape=input_shape), LSTM(50, activation="relu"), Dense(1)]
+        )
+        model.compile(optimizer="adam", loss="mse")
+        return model
+
+    def _prepare_data(self) -> np.ndarray:
+        return self.scaler.fit_transform(self.df[["price"]])
+
+    def backtest(self) -> float:
+        scaled = self._prepare_data()
+
+        X_train, y_train = [], []
+        for i in range(self.train_size - self.seq_len):
+            X_train.append(scaled[i : i + self.seq_len])
+            y_train.append(scaled[i + self.seq_len])
+        self.model.fit(np.array(X_train), np.array(y_train), epochs=self.epochs, verbose=0)
+
+        balance = self.initial_balance
+        holdings = 0.0
+        for i in range(self.train_size, len(self.df) - 1):
+            seq = scaled[i - self.seq_len : i]
+            pred_scaled = self.model.predict(seq[np.newaxis, :, :], verbose=0)[0, 0]
+            pred = self.scaler.inverse_transform([[pred_scaled]])[0, 0]
+            price = self.df["price"].iloc[i]
+
+            if pred > price and balance > 0:
+                qty = balance / price
+                balance -= qty * price * (1 + self.commission)
+                holdings += qty
+                self.trades.append({"time": self.df.index[i], "type": "BUY", "price": price, "qty": qty})
+            elif pred < price and holdings > 0:
+                balance += holdings * price * (1 - self.commission)
+                self.trades.append({"time": self.df.index[i], "type": "SELL", "price": price, "qty": holdings})
+                holdings = 0.0
+
+        if holdings > 0:
+            final_price = self.df["price"].iloc[-1]
+            balance += holdings * final_price * (1 - self.commission)
+            self.trades.append({"time": self.df.index[-1], "type": "SELL", "price": final_price, "qty": holdings})
+        return balance
+
 
 def plot_predictions(df: pd.DataFrame, predictions: pd.Series, outfile: str = "prediction.png") -> None:
     """Plot actual prices and predicted future prices."""
@@ -223,7 +344,13 @@ def plot_predictions(df: pd.DataFrame, predictions: pd.Series, outfile: str = "p
 
 
 def main() -> None:
-    fetcher = DataFetcher()
+    parser = argparse.ArgumentParser(description="Blockasset price prediction")
+    parser.add_argument(
+        "--csv", help="Use local CSV file instead of downloading from CoinGecko"
+    )
+    args = parser.parse_args()
+
+    fetcher = DataFetcher(local_csv=args.csv)
     raw_df = fetcher.fetch()
     print(f"Training data starts at {raw_df.index[0]:%Y-%m-%d %H:%M:%S}")
 
@@ -242,6 +369,21 @@ def main() -> None:
     for res in results:
         print(f"End of {res.month}: ${res.balance:.2f}")
     print(f"\nFinal balance on 2025-10-31: ${results[-1].balance:.2f}")
+
+    # Show an example of daily balances
+    daily_results = simulator.run_daily()
+    print("\nFirst 7 daily balances:")
+    for res in daily_results[:7]:
+        print(f"{res.month}: ${res.balance:.2f}")
+
+    # Demonstrate LSTM-based trading
+    trader = LSTMTrader(raw_df)
+    final_balance = trader.backtest()
+    print(f"\nLSTM trading simulation final balance: ${final_balance:.2f}")
+    if trader.trades:
+        print("First 3 trades:")
+        for t in trader.trades[:3]:
+            print(f"{t['time']:%Y-%m-%d %H:%M} {t['type']} at ${t['price']:.4f} qty {t['qty']:.4f}")
 
 
 if __name__ == "__main__":

--- a/block_analysis.py
+++ b/block_analysis.py
@@ -343,6 +343,42 @@ def plot_predictions(df: pd.DataFrame, predictions: pd.Series, outfile: str = "p
     plt.savefig(outfile)
 
 
+def plot_trades(
+    df: pd.DataFrame, trades: List[dict], outfile: str = "trades.png"
+) -> None:
+    """Plot buy/sell trades overlaid on the price chart."""
+    if not trades:
+        return
+
+    ax = df["price"].plot(title="LSTM Trader Backtest", figsize=(10, 5))
+    buys = [t for t in trades if t["type"] == "BUY"]
+    sells = [t for t in trades if t["type"] == "SELL"]
+
+    if buys:
+        ax.scatter(
+            [t["time"] for t in buys],
+            [t["price"] for t in buys],
+            color="green",
+            marker="^",
+            label="BUY",
+        )
+
+    if sells:
+        ax.scatter(
+            [t["time"] for t in sells],
+            [t["price"] for t in sells],
+            color="red",
+            marker="v",
+            label="SELL",
+        )
+
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Price (USD)")
+    ax.legend()
+    plt.tight_layout()
+    plt.savefig(outfile)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Blockasset price prediction")
     parser.add_argument(
@@ -384,6 +420,7 @@ def main() -> None:
         print("First 3 trades:")
         for t in trader.trades[:3]:
             print(f"{t['time']:%Y-%m-%d %H:%M} {t['type']} at ${t['price']:.4f} qty {t['qty']:.4f}")
+        plot_trades(raw_df, trader.trades)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry CoinGecko requests with exponential backoff
- document automatic retry behaviour in README
- allow analysis script to load prices from a local CSV file

## Testing
- `pip install -r requirements.txt`
- `python fetch_ohlc.py --days 1 --outfile sample.csv`
- `python block_analysis.py --csv sample.csv` *(fails: not enough data for training)*

------
https://chatgpt.com/codex/tasks/task_e_685c941513fc8325b4e2a325598d397c